### PR TITLE
Update runtime to 23.08

### DIFF
--- a/com.github.muriloventuroso.pdftricks.json
+++ b/com.github.muriloventuroso.pdftricks.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.github.muriloventuroso.pdftricks",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "base": "io.elementary.BaseApp",
-    "base-version": "juno-22.08",
+    "base-version": "juno-23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "com.github.muriloventuroso.pdftricks",
     "finish-args": [


### PR DESCRIPTION
23.08 is the latest available runtime for Juno. Fixes https://github.com/flathub/com.github.muriloventuroso.pdftricks/issues/9