### PR TITLE
Upgrade freedesktop runtime and dependencies

### DIFF
--- a/com.github.muriloventuroso.pdftricks.json
+++ b/com.github.muriloventuroso.pdftricks.json
@@ -1,10 +1,10 @@
 {
     "app-id": "com.github.muriloventuroso.pdftricks",
-    "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
     "base": "io.elementary.BaseApp",
-    "base-version": "juno-22.08",
-    "sdk": "org.freedesktop.Sdk",
+  "base-version": "juno-23.08",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "46",
+  "sdk": "org.gnome.Sdk",
     "command": "com.github.muriloventuroso.pdftricks",
     "finish-args": [
         "--share=ipc",
@@ -13,27 +13,23 @@
         "--socket=wayland"
     ],
 
-    "modules": [{
+  "modules": [
+    {
             "name": "libpng",
-            "config-opts": [
-                "--disable-static"
-            ],
-            "cleanup": [
-                "/bin",
-                "/include",
-                "/lib/pkgconfig",
-                "/share"
-            ],
-            "sources": [{
+      "config-opts": ["--disable-static"],
+      "cleanup": ["/bin", "/include", "/lib/pkgconfig", "/share"],
+      "sources": [
+        {
                 "__comment": "Must be version 1.2.x",
                 "type": "archive",
                 "url": "https://downloads.sourceforge.net/project/libpng/libpng12/1.2.59/libpng-1.2.59.tar.xz",
                 "sha256": "b4635f15b8adccc8ad0934eea485ef59cc4cae24d0f0300a9a941e51974ffcc7"
-            }]
+        }
+      ]
         },
         {
             "name": "ghostscript",
-            "config-opts": ["--disable-cups"],
+      "config-opts": ["--disable-cups", "--disable-gtk"],
             "build-options": {
               "arch": {
                 "aarch64": {
@@ -74,7 +70,8 @@
                 "/bin/ps2ps2",
                 "/bin/unix-lpr.sh"
             ],
-            "sources": [{
+      "sources": [
+        {
                     "type": "archive",
                     "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9540/ghostscript-9.54.0.tar.xz",
                     "sha256": "c2b7b43cde600f4e70efb2cd95865f6d884a67315c3de235914697d8ccde6e3b"
@@ -96,10 +93,11 @@
                 "--with-gvc=no",
                 "--enable-zero-configuration"
             ],
-            "sources": [{
+      "sources": [
+        {
                     "type": "archive",
-                    "url": "https://imagemagick.org/archive/ImageMagick-7.1.0-61.tar.xz",
-                    "sha256": "4b4f9437666ef1a87df69b34bc8abdf7ad05d524c00dd1d63f6699e6ab1ed94e"
+          "url": "https://imagemagick.org/archive/ImageMagick-7.1.1-43.tar.xz",
+          "sha256": "fa79401342b409b9b7f7d3146bd6595787373811e72be1669c39b58d1489da4f"
                 },
                 {
                     "type": "patch",
@@ -110,7 +108,8 @@
         {
             "name": "pdftricks",
             "buildsystem": "meson",
-            "sources": [{
+      "sources": [
+        {
                     "type": "archive",
                     "url": "https://github.com/muriloventuroso/pdftricks/archive/0.4.1.tar.gz",
                     "sha256": "4b0fa5d73621ef42d6d0040ec2147a43bae2337ea722651525f080f2ae78bea3"

--- a/com.github.muriloventuroso.pdftricks.json
+++ b/com.github.muriloventuroso.pdftricks.json
@@ -1,10 +1,10 @@
 {
     "app-id": "com.github.muriloventuroso.pdftricks",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "24.08",
     "base": "io.elementary.BaseApp",
-  "base-version": "juno-23.08",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "46",
-  "sdk": "org.gnome.Sdk",
+    "base-version": "juno-23.08",
+    "sdk": "org.freedesktop.Sdk",
     "command": "com.github.muriloventuroso.pdftricks",
     "finish-args": [
         "--share=ipc",
@@ -13,23 +13,27 @@
         "--socket=wayland"
     ],
 
-  "modules": [
-    {
+    "modules": [{
             "name": "libpng",
-      "config-opts": ["--disable-static"],
-      "cleanup": ["/bin", "/include", "/lib/pkgconfig", "/share"],
-      "sources": [
-        {
+            "config-opts": [
+                "--disable-static"
+            ],
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/pkgconfig",
+                "/share"
+            ],
+            "sources": [{
                 "__comment": "Must be version 1.2.x",
                 "type": "archive",
                 "url": "https://downloads.sourceforge.net/project/libpng/libpng12/1.2.59/libpng-1.2.59.tar.xz",
                 "sha256": "b4635f15b8adccc8ad0934eea485ef59cc4cae24d0f0300a9a941e51974ffcc7"
-        }
-      ]
+            }]
         },
         {
             "name": "ghostscript",
-      "config-opts": ["--disable-cups", "--disable-gtk"],
+            "config-opts": ["--disable-cups", "--disable-gtk"],
             "build-options": {
               "arch": {
                 "aarch64": {
@@ -70,8 +74,7 @@
                 "/bin/ps2ps2",
                 "/bin/unix-lpr.sh"
             ],
-      "sources": [
-        {
+            "sources": [{
                     "type": "archive",
                     "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9540/ghostscript-9.54.0.tar.xz",
                     "sha256": "c2b7b43cde600f4e70efb2cd95865f6d884a67315c3de235914697d8ccde6e3b"
@@ -93,11 +96,10 @@
                 "--with-gvc=no",
                 "--enable-zero-configuration"
             ],
-      "sources": [
-        {
+            "sources": [{
                     "type": "archive",
-          "url": "https://imagemagick.org/archive/ImageMagick-7.1.1-43.tar.xz",
-          "sha256": "fa79401342b409b9b7f7d3146bd6595787373811e72be1669c39b58d1489da4f"
+                    "url": "https://imagemagick.org/archive/ImageMagick-7.1.1-43.tar.xz",
+                    "sha256": "fa79401342b409b9b7f7d3146bd6595787373811e72be1669c39b58d1489da4f"
                 },
                 {
                     "type": "patch",
@@ -108,8 +110,7 @@
         {
             "name": "pdftricks",
             "buildsystem": "meson",
-      "sources": [
-        {
+            "sources": [{
                     "type": "archive",
                     "url": "https://github.com/muriloventuroso/pdftricks/archive/0.4.1.tar.gz",
                     "sha256": "4b0fa5d73621ef42d6d0040ec2147a43bae2337ea722651525f080f2ae78bea3"

--- a/com.github.muriloventuroso.pdftricks.json
+++ b/com.github.muriloventuroso.pdftricks.json
@@ -118,7 +118,7 @@
                 {
                     "type": "patch",
                     "paths": [
-                        "patches/appdata-keys.patch",
+                        "patches/appdata-linter-validations.patch",
                         "patches/apply-eos-theme.patch",
                         "patches/pdftricks-meson.patch"
                     ]

--- a/com.github.muriloventuroso.pdftricks.json
+++ b/com.github.muriloventuroso.pdftricks.json
@@ -118,10 +118,15 @@
                 {
                     "type": "patch",
                     "paths": [
+                        "patches/appdata-keys.patch",
                         "patches/apply-eos-theme.patch",
                         "patches/pdftricks-meson.patch"
                     ]
                 }
+            ],
+            "post-install" : [
+                "mkdir -p /app/share/icons/hicolor/scalable/apps && mv /app/share/icons/hicolor/128x128@2/apps/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
+                "find /app/share/icons/hicolor -type f -not -path \"*scalable*\" -not -path \"*actions*\" -name \"*.svg\" -delete"
             ]
         }
     ]

--- a/com.github.muriloventuroso.pdftricks.json
+++ b/com.github.muriloventuroso.pdftricks.json
@@ -3,7 +3,7 @@
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "24.08",
     "base": "io.elementary.BaseApp",
-    "base-version": "juno-23.08",
+    "base-version": "circe-24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "com.github.muriloventuroso.pdftricks",
     "finish-args": [

--- a/com.github.muriloventuroso.pdftricks.json
+++ b/com.github.muriloventuroso.pdftricks.json
@@ -1,9 +1,9 @@
 {
     "app-id": "com.github.muriloventuroso.pdftricks",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "24.08",
+    "runtime-version": "23.08",
     "base": "io.elementary.BaseApp",
-    "base-version": "circe-24.08",
+    "base-version": "juno-23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "com.github.muriloventuroso.pdftricks",
     "finish-args": [

--- a/com.github.muriloventuroso.pdftricks.json
+++ b/com.github.muriloventuroso.pdftricks.json
@@ -27,8 +27,8 @@
             "sources": [{
                 "__comment": "Must be version 1.2.x",
                 "type": "archive",
-                "url": "https://downloads.sourceforge.net/project/libpng/libpng12/1.2.59/libpng-1.2.59.tar.xz",
-                "sha256": "b4635f15b8adccc8ad0934eea485ef59cc4cae24d0f0300a9a941e51974ffcc7"
+                "url": "https://downloads.sourceforge.net/project/libpng/libpng16/1.6.46/libpng-1.6.46.tar.xz",
+                "sha256": "f3aa8b7003998ab92a4e9906c18d19853e999f9d3bca9bd1668f54fa81707cb1"
             }]
         },
         {

--- a/patches/appdata-keys.patch
+++ b/patches/appdata-keys.patch
@@ -1,0 +1,21 @@
+diff --git a/data/com.github.muriloventuroso.pdftricks.appdata.xml.in b/data/com.github.muriloventuroso.pdftricks.appdata.xml.in
+index aa5836a..6e5c84a 100644
+--- a/data/com.github.muriloventuroso.pdftricks.appdata.xml.in
++++ b/data/com.github.muriloventuroso.pdftricks.appdata.xml.in
+@@ -5,8 +5,6 @@
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_group>MuriloVenturoso</project_group>
+   <project_license>GPL-3.0+</project_license>
+-  <value key="x-appcenter-suggested-price">1</value>
+-  <value key="x-appcenter-stripe">pk_live_8nDudUPTmiwzRlzvKulsBlVm</value>
+   <name>PDF Tricks</name>
+   <summary>Tricks for PDF Files</summary>
+   <description>
+@@ -172,6 +170,7 @@
+   <custom>
+     <value key="x-appcenter-color-primary">#F6546A</value>
+     <value key="x-appcenter-color-primary-text">#fff</value>
++    <value key="x-appcenter-stripe">pk_live_8nDudUPTmiwzRlzvKulsBlVm</value>
+     <value key="x-appcenter-suggested-price">2</value>
+   </custom>
+ </component>

--- a/patches/appdata-linter-validations.patch
+++ b/patches/appdata-linter-validations.patch
@@ -1,8 +1,8 @@
 diff --git a/data/com.github.muriloventuroso.pdftricks.appdata.xml.in b/data/com.github.muriloventuroso.pdftricks.appdata.xml.in
-index aa5836a..6e5c84a 100644
+index aa5836a..6a555a0 100644
 --- a/data/com.github.muriloventuroso.pdftricks.appdata.xml.in
 +++ b/data/com.github.muriloventuroso.pdftricks.appdata.xml.in
-@@ -5,8 +5,6 @@
+@@ -5,10 +5,9 @@
    <metadata_license>CC0-1.0</metadata_license>
    <project_group>MuriloVenturoso</project_group>
    <project_license>GPL-3.0+</project_license>
@@ -10,8 +10,11 @@ index aa5836a..6e5c84a 100644
 -  <value key="x-appcenter-stripe">pk_live_8nDudUPTmiwzRlzvKulsBlVm</value>
    <name>PDF Tricks</name>
    <summary>Tricks for PDF Files</summary>
++  <launchable type="desktop-id">com.github.muriloventuroso.pdftricks.desktop</launchable>
    <description>
-@@ -172,6 +170,7 @@
+     <p>A simple, efficient application for small manipulations in PDF files. </p>
+     <ul>
+@@ -172,6 +171,7 @@
    <custom>
      <value key="x-appcenter-color-primary">#F6546A</value>
      <value key="x-appcenter-color-primary-text">#fff</value>


### PR DESCRIPTION
Freedesktop 22.08 is EOL, this upgrades it and:

* Upgrade runtime version
* Upgrade base version
* Upgrade dependencies
* Fix validation errors

Please squash & merge. Thanks